### PR TITLE
Support Commands

### DIFF
--- a/src/Http/Controllers/RafterCommandRunController.php
+++ b/src/Http/Controllers/RafterCommandRunController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Rafter\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Artisan;
+
+class RafterCommandRunController extends Controller
+{
+    public function __invoke(Request $request)
+    {
+        Artisan::call($request->command);
+        return Artisan::output();
+    }
+}

--- a/src/Rafter.php
+++ b/src/Rafter.php
@@ -6,6 +6,7 @@ class Rafter
 {
     const QUEUE_ROUTE = '/_rafter/queue/work';
     const SCHEDULE_ROUTE = '/_rafter/schedule/run';
+    const COMMAND_ROUTE = '/_rafter/command/run';
 
     /**
      * Get the URL to the queue worker

--- a/src/RafterServiceProvider.php
+++ b/src/RafterServiceProvider.php
@@ -56,9 +56,11 @@ class RafterServiceProvider extends ServiceProvider
         }
 
         // Handle queue jobs
-        Route::group(['middleware' => [VerifyGoogleOidcToken::class, EnsureRafterWorker::class]], function () {
+        // Route::group(['middleware' => [VerifyGoogleOidcToken::class, EnsureRafterWorker::class]], function () {
+        Route::group(['middleware' => [EnsureRafterWorker::class]], function () {
             Route::post(Rafter::QUEUE_ROUTE, 'Rafter\Http\Controllers\RafterQueueWorkerController');
             Route::post(Rafter::SCHEDULE_ROUTE, 'Rafter\Http\Controllers\RafterScheduleRunController');
+            Route::post(Rafter::COMMAND_ROUTE, 'Rafter\Http\Controllers\RafterCommandRunController');
         });
     }
 

--- a/src/RafterServiceProvider.php
+++ b/src/RafterServiceProvider.php
@@ -55,8 +55,7 @@ class RafterServiceProvider extends ServiceProvider
             return;
         }
 
-        // Handle queue jobs
-        // Route::group(['middleware' => [VerifyGoogleOidcToken::class, EnsureRafterWorker::class]], function () {
+        // Handle worker jobs and commands
         Route::group(['middleware' => [EnsureRafterWorker::class]], function () {
             Route::post(Rafter::QUEUE_ROUTE, 'Rafter\Http\Controllers\RafterQueueWorkerController');
             Route::post(Rafter::SCHEDULE_ROUTE, 'Rafter\Http\Controllers\RafterScheduleRunController');


### PR DESCRIPTION
- Runs a command
- Returns the response
- Also removes the Verify OIDC middleware - don't need it because Cloud Run does this for us. But left the middleware available in case we want to test locally.

Fixes https://github.com/rafter-platform/rafter/issues/33